### PR TITLE
Add configurable description and tags to TFE projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ module "projecter" {
   organization = "my-tfc-org"
   project_name = "my-new-project"
   description  = "My project description"
-  tag_names    = ["tag1", "tag2"]
+  tags = {
+    environment = "production"
+    team        = "platform"
+  }
 
   team_access = {
     tfc-admins = "admin"
@@ -23,11 +26,15 @@ module "projecter" {
 See the [examples](./examples/) directory for more detailed scenarios.
 
 ### Project Description and Tags
-The `description` and `tag_names` input variables are optional and can be used to provide additional metadata for the Project.
+The `description` and `tags` input variables are optional and can be used to provide additional metadata for the Project.
 
 ```hcl
   description = "Production environment project"
-  tag_names   = ["production", "aws", "team-platform"]
+  tags = {
+    environment = "production"
+    service     = "aws"
+    team        = "platform"
+  }
 ```
 
 ### Team Access

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ module "projecter" {
 
   organization = "my-tfc-org"
   project_name = "my-new-project"
+  description  = "My project description"
+  tag_names    = ["tag1", "tag2"]
 
   team_access = {
     tfc-admins = "admin"
@@ -19,6 +21,14 @@ module "projecter" {
 > Note: Setting a `TFE_TOKEN` environment variable is the recommended approach for the TFE provider auth. Alternatively, you could run `terraform login`.
 
 See the [examples](./examples/) directory for more detailed scenarios.
+
+### Project Description and Tags
+The `description` and `tag_names` input variables are optional and can be used to provide additional metadata for the Project.
+
+```hcl
+  description = "Production environment project"
+  tag_names   = ["production", "aws", "team-platform"]
+```
 
 ### Team Access
 To configure RBAC on the Project, there are two options:

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -3,4 +3,6 @@ module "projecter" {
   
   organization = var.organization
   project_name = var.project_name
+  description  = var.description
+  tag_names    = var.tag_names
 }

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -4,5 +4,5 @@ module "projecter" {
   organization = var.organization
   project_name = var.project_name
   description  = var.description
-  tag_names    = var.tag_names
+  tags         = var.tags
 }

--- a/examples/basic/variables.tf
+++ b/examples/basic/variables.tf
@@ -19,8 +19,8 @@ variable "description" {
   default     = null
 }
 
-variable "tag_names" {
-  type        = list(string)
-  description = "List of tag names to apply to Project."
-  default     = []
+variable "tags" {
+  type        = map(string)
+  description = "Map of key-value tags to apply to Project."
+  default     = {}
 }

--- a/examples/basic/variables.tf
+++ b/examples/basic/variables.tf
@@ -12,3 +12,15 @@ variable "project_name" {
     error_message = "Project name must be between 3 and 36 characters in length."
   }
 }
+
+variable "description" {
+  type        = string
+  description = "Description of Project."
+  default     = null
+}
+
+variable "tag_names" {
+  type        = list(string)
+  description = "List of tag names to apply to Project."
+  default     = []
+}

--- a/examples/for-each/main.tf
+++ b/examples/for-each/main.tf
@@ -5,6 +5,8 @@ module "projects" {
 
   organization = var.organization
   project_name = each.key
+  description  = each.value.description
+  tag_names    = each.value.tag_names
 
   team_access        = each.value.team_access
   custom_team_access = each.value.custom_team_access

--- a/examples/for-each/main.tf
+++ b/examples/for-each/main.tf
@@ -6,7 +6,7 @@ module "projects" {
   organization = var.organization
   project_name = each.key
   description  = each.value.description
-  tag_names    = each.value.tag_names
+  tags         = each.value.tags
 
   team_access        = each.value.team_access
   custom_team_access = each.value.custom_team_access

--- a/examples/for-each/variables.tf
+++ b/examples/for-each/variables.tf
@@ -2,7 +2,7 @@ variable "projects" {
   type = map(
     object({
       description = optional(string, null)
-      tag_names   = optional(list(string), [])
+      tags        = optional(map(string), {})
       team_access = optional(map(string), {})
       custom_team_access = optional(map(object({
         project_access = object({

--- a/examples/for-each/variables.tf
+++ b/examples/for-each/variables.tf
@@ -1,6 +1,8 @@
 variable "projects" {
   type = map(
     object({
+      description = optional(string, null)
+      tag_names   = optional(list(string), [])
       team_access = optional(map(string), {})
       custom_team_access = optional(map(object({
         project_access = object({

--- a/examples/full/main.tf
+++ b/examples/full/main.tf
@@ -4,7 +4,7 @@ module "projecter" {
   organization = var.organization
   project_name = var.project_name
   description  = var.description
-  tag_names    = var.tag_names
+  tags         = var.tags
   
   team_access        = var.team_access
   custom_team_access = var.custom_team_access

--- a/examples/full/main.tf
+++ b/examples/full/main.tf
@@ -3,6 +3,8 @@ module "projecter" {
 
   organization = var.organization
   project_name = var.project_name
+  description  = var.description
+  tag_names    = var.tag_names
   
   team_access        = var.team_access
   custom_team_access = var.custom_team_access

--- a/examples/full/variables.tf
+++ b/examples/full/variables.tf
@@ -14,10 +14,10 @@ variable "description" {
   default     = null
 }
 
-variable "tag_names" {
-  type        = list(string)
-  description = "List of tag names to apply to Project."
-  default     = []
+variable "tags" {
+  type        = map(string)
+  description = "Map of key-value tags to apply to Project."
+  default     = {}
 }
 
 variable "team_access" {

--- a/examples/full/variables.tf
+++ b/examples/full/variables.tf
@@ -8,6 +8,18 @@ variable "project_name" {
   description = "Name of Project."
 }
 
+variable "description" {
+  type        = string
+  description = "Description of Project."
+  default     = null
+}
+
+variable "tag_names" {
+  type        = list(string)
+  description = "List of tag names to apply to Project."
+  default     = []
+}
+
 variable "team_access" {
   type        = map(string)
   description = "Map of existing Team(s) and built-in permissions to grant on Project."

--- a/outputs.tf
+++ b/outputs.tf
@@ -21,9 +21,9 @@ output "description" {
   value       = tfe_project.project.description
 }
 
-output "tag_names" {
-  description = "Tag names applied to the project"
-  value       = tfe_project.project.tag_names
+output "tags" {
+  description = "Tags applied to the project"
+  value       = tfe_project.project.tags
 }
 
 #------------------------------------------------------------------------------

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,56 @@
+#------------------------------------------------------------------------------
+# Project Outputs
+#------------------------------------------------------------------------------
+output "project_id" {
+  description = "ID of the project"
+  value       = tfe_project.project.id
+}
+
+output "project_name" {
+  description = "Name of the project"
+  value       = tfe_project.project.name
+}
+
+output "organization" {
+  description = "Organization that the project belongs to"
+  value       = tfe_project.project.organization
+}
+
+#------------------------------------------------------------------------------
+# Team Access Outputs
+#------------------------------------------------------------------------------
+output "team_access_ids" {
+  description = "Map of team names to their project access resource IDs (fixed permissions)"
+  value       = { for k, v in tfe_team_project_access.managed : k => v.id }
+}
+
+output "custom_team_access_ids" {
+  description = "Map of team names to their project access resource IDs (custom permissions)."
+  value       = { for k, v in tfe_team_project_access.custom : k => v.id }
+}
+
+#------------------------------------------------------------------------------
+# Variable Set Outputs
+#------------------------------------------------------------------------------
+output "variable_set_ids" {
+  description = "Map of variable set names to their IDs applied to the project"
+  value       = { for k, v in data.tfe_variable_set.vs : k => v.id }
+}
+
+output "project_variable_set_ids" {
+  description = "Map of variable set names to their project variable set resource IDs"
+  value       = { for k, v in tfe_project_variable_set.vs : k => v.id }
+}
+
+#------------------------------------------------------------------------------
+# Policy Set Outputs
+#------------------------------------------------------------------------------
+output "policy_set_ids" {
+  description = "Map of policy set names to their IDs enforced on the project"
+  value       = { for k, v in data.tfe_policy_set.ps : k => v.id }
+}
+
+output "project_policy_set_ids" {
+  description = "Map of policy set names to their project policy set resource IDs"
+  value       = { for k, v in tfe_project_policy_set.ps : k => v.id }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -16,6 +16,16 @@ output "organization" {
   value       = tfe_project.project.organization
 }
 
+output "description" {
+  description = "Description of the project"
+  value       = tfe_project.project.description
+}
+
+output "tag_names" {
+  description = "Tag names applied to the project"
+  value       = tfe_project.project.tag_names
+}
+
 #------------------------------------------------------------------------------
 # Team Access Outputs
 #------------------------------------------------------------------------------

--- a/project.tf
+++ b/project.tf
@@ -1,4 +1,6 @@
 resource "tfe_project" "project" {
   name         = var.project_name
   organization = var.organization
+  description  = var.description
+  tag_names    = var.tag_names
 }

--- a/project.tf
+++ b/project.tf
@@ -2,5 +2,5 @@ resource "tfe_project" "project" {
   name         = var.project_name
   organization = var.organization
   description  = var.description
-  tag_names    = var.tag_names
+  tags         = var.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,18 @@ variable "project_name" {
   }
 }
 
+variable "description" {
+  type        = string
+  description = "Description of Project."
+  default     = null
+}
+
+variable "tag_names" {
+  type        = list(string)
+  description = "List of tag names to apply to Project."
+  default     = []
+}
+
 #------------------------------------------------------------------------------
 # Project Team Access
 #------------------------------------------------------------------------------

--- a/variables.tf
+++ b/variables.tf
@@ -22,10 +22,10 @@ variable "description" {
   default     = null
 }
 
-variable "tag_names" {
-  type        = list(string)
-  description = "List of tag names to apply to Project."
-  default     = []
+variable "tags" {
+  type        = map(string)
+  description = "Map of key-value tags to apply to Project."
+  default     = {}
 }
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds support for configurable project descriptions and tags in the Terraform module, addressing the requirement to make TFE project's description and tags configurable.

## Changes

### New Optional Variables
Added two new optional input variables to the module:
- `description` (string, default: `null`) - Allows setting a description for the TFE project
- `tags` (map(string), default: `{}`) - Allows applying key-value tags to the TFE project

### Core Module Updates
- Updated `project.tf` to pass the new variables to the `tfe_project` resource
- Added corresponding outputs in `outputs.tf` to expose the description and tags values

### Documentation
Enhanced the README with a new "Project Description and Tags" section demonstrating usage:

```hcl
module "projecter" {
  source  = "alexbasista/projecter/tfe"
  
  organization = "my-tfc-org"
  project_name = "my-new-project"
  description  = "Production environment project"
  tags = {
    environment = "production"
    service     = "aws"
    team        = "platform"
  }
}
```

### Examples
Updated all three examples (basic, full, and for-each) to include the new optional parameters, ensuring users have clear guidance on how to use these features.

## Backward Compatibility

Both variables are optional with sensible defaults, ensuring this change is fully backward compatible. Existing configurations will continue to work without modification.